### PR TITLE
Feature/codename safe sync

### DIFF
--- a/src/modules/sync/diff/combinators.ts
+++ b/src/modules/sync/diff/combinators.ts
@@ -391,6 +391,78 @@ export const makePrefixHandler =
  *
  * @param arrayHandler - handler that creates 'addInto', 'replace' and 'remove' operations.
  *
+ * @param options - Optional configuration object.
+ * @param options.groupBy - Optional function to obtain property on which the entities should be grouped by
+ * (if unspecified all entities are considered to be in the same group).
+ * Only entities inside groups are ordered, however, groups are not ordered amongst themselves.
+ * @param options.filter - Optional function to filter entities from source before ordering with move operations.
+ */
+export const makeCodenameOrderingHandler =
+  <Entity extends { name: string; codename: string }>(
+    arrayHandler: Handler<readonly Entity[]>,
+    {
+      groupBy = () => "",
+      filter = () => true,
+    }: {
+      groupBy?: (el: Entity) => string;
+      filter?: (el: Entity) => boolean;
+    } = {},
+  ): Handler<readonly Entity[]> =>
+  (sourceValue, targetValue) => {
+    const targetWithoutRemoved = targetValue.filter((target) =>
+      sourceValue.some(
+        (source) =>
+          source.name === target.name || source.codename === target.codename,
+      ),
+    );
+
+    const sortedSourceElements = sourceValue.toSorted((e1, e2) =>
+      groupBy(e1) < groupBy(e2) ? -2 : 0,
+    );
+    const sortedTargetElements = targetWithoutRemoved.toSorted((e1, e2) =>
+      groupBy(e1) < groupBy(e2) ? -2 : 0,
+    );
+
+    const sourceEntityGroups = sourceValue.reduce((prev, entity) => {
+      prev.set(groupBy(entity), [...(prev.get(groupBy(entity)) ?? []), entity]);
+
+      return prev;
+    }, new Map<string, Array<Entity>>());
+
+    const isSorted = zip(sortedSourceElements, sortedTargetElements).every(
+      ([e1, e2]) => e1.name === e2.name || e1.codename === e2.codename,
+    );
+
+    const moveOps = isSorted
+      ? []
+      : Array.from(sourceEntityGroups.values()).flatMap((group) => {
+          const filteredArray = group.filter(filter);
+
+          return filteredArray.length <= 1
+            ? []
+            : filteredArray.slice(1).map((entity, index) => ({
+                op: "move" as const,
+                path: `/codename:${entity.codename}`,
+                after: {
+                  codename: (filteredArray[index] as Entity).codename,
+                },
+              }));
+        });
+
+    return [...arrayHandler(sourceValue, targetValue), ...moveOps];
+  };
+
+/**
+ * Creates move operations for entities in an array.
+ * It matches the entities by codename and creates "move" operations and concatenates operations
+ * from arrayHandler.
+ *
+ * Unless the target is ordered same as the source, the algorithm generates one move operation
+ * for every element except the first one in each group and assigns them the "after" property
+ * to reference the previous element from source
+ *
+ * @param arrayHandler - handler that creates 'addInto', 'replace' and 'remove' operations.
+ *
  * @param getCodename - function to obtain codename from entity (entities are sorted based on codename)
  *
  * @param options - Optional configuration object.

--- a/src/modules/sync/diff/combinators.ts
+++ b/src/modules/sync/diff/combinators.ts
@@ -1,5 +1,8 @@
 import { zip } from "../../../utils/array.js";
-import { PatchOperation } from "../types/patchOperation.js";
+import {
+  PatchOperation,
+  ReplacePatchOperation,
+} from "../types/patchOperation.js";
 
 export type Handler<Entity> = (
   sourceValue: Entity,
@@ -249,27 +252,39 @@ export const makeCodenameBaseArrayHandler =
         ];
       }
 
-      if (targetEntity.codename !== source.codename) {
-        return [
-          {
-            op: "replace" as const,
-            oldValue: targetEntity.codename,
-            value: source.codename,
-            path: `/${targetEntity.codename}/codename`,
-          },
-          // TODO: See if we need this for when there's other differences. It currently doesn't play nice
-          // with at least one of the current tests, so additional logic might need to be added if it's needed
-          // ...getCreateUpdateOps()(source, targetEntity).map(
-          //   prefixOperationPath(source.codename ?? ""),
-          // ),
-        ];
-      }
-
-      return [
+      const ops = [
         ...getCreateUpdateOps()(source, targetEntity).map(
           prefixOperationPath(source.codename ?? ""),
         ),
       ];
+
+      if (targetEntity.codename !== source.codename) {
+        const codenameOp = {
+          op: "replace" as const,
+          oldValue: targetEntity.codename,
+          value: source.codename,
+          path: `/${targetEntity.codename}/codename`,
+        };
+
+        return [
+          codenameOp,
+          // Removes any duplicate codename operations that are generated from getCreateUpdateOps()
+          ...ops.filter(
+            (op) =>
+              !ops.some((op2) => {
+                const opCast = op as ReplacePatchOperation;
+                const op2Cast = op2 as ReplacePatchOperation;
+
+                return (
+                  opCast.oldValue === op2Cast.oldValue &&
+                  opCast.value === op2Cast.value
+                );
+              }),
+          ),
+        ];
+      }
+
+      return ops;
     });
 
     const removeOps = targetValue

--- a/src/modules/sync/diff/combinators.ts
+++ b/src/modules/sync/diff/combinators.ts
@@ -257,9 +257,11 @@ export const makeCodenameBaseArrayHandler =
             value: source.codename,
             path: `/${targetEntity.codename}/codename`,
           },
-          ...getCreateUpdateOps()(source, targetEntity).map(
-            prefixOperationPath(source.codename ?? ""),
-          ),
+          // TODO: See if we need this for when there's other differences. It currently doesn't play nice
+          // with at least one of the current tests, so additional logic might need to be added if it's needed
+          // ...getCreateUpdateOps()(source, targetEntity).map(
+          //   prefixOperationPath(source.codename ?? ""),
+          // ),
         ];
       }
 

--- a/src/modules/sync/diff/combinators.ts
+++ b/src/modules/sync/diff/combinators.ts
@@ -36,7 +36,9 @@ export const makeCodenameObjectHandler =
 
     if (
       sourceValue.codename !== targetValue.codename &&
-      sourceValue.name === targetValue.name
+      sourceValue.name === targetValue.name &&
+      !!sourceValue.name &&
+      !!targetValue.name
     ) {
       customOps.push({
         op: "replace",
@@ -239,7 +241,8 @@ export const makeCodenameBaseArrayHandler =
     const addAndUpdateOps = sourceValue.flatMap((source) => {
       const targetEntity = targetValue.find(
         (target) =>
-          target.codename === source.codename || target.name === source.name,
+          target.codename === source.codename ||
+          (target.name === source.name && !!target.name && !!source.name),
       );
 
       if (!targetEntity) {
@@ -293,7 +296,7 @@ export const makeCodenameBaseArrayHandler =
           !sourceValue.find(
             (source) =>
               target.codename === source.codename ||
-              target.name === source.name,
+              (target.name === source.name && !!target.name && !!source.name),
           ),
       )
       .map((target) => ({
@@ -427,7 +430,8 @@ export const makeCodenameOrderingHandler =
     const targetWithoutRemoved = targetValue.filter((target) =>
       sourceValue.some(
         (source) =>
-          source.name === target.name || source.codename === target.codename,
+          source.codename === target.codename ||
+          (source.name === target.name && !!source.name && !!target.name),
       ),
     );
 
@@ -445,7 +449,9 @@ export const makeCodenameOrderingHandler =
     }, new Map<string, Array<Entity>>());
 
     const isSorted = zip(sortedSourceElements, sortedTargetElements).every(
-      ([e1, e2]) => e1.name === e2.name || e1.codename === e2.codename,
+      ([e1, e2]) =>
+        e1.codename === e2.codename ||
+        (e1.name === e2.name && !!e1.name && !!e2.name),
     );
 
     const moveOps = isSorted

--- a/src/modules/sync/diff/combinators.ts
+++ b/src/modules/sync/diff/combinators.ts
@@ -14,6 +14,68 @@ export type ContextfulHandler<Context, Entity> = Readonly<{
  *
  * @param innerHandlers - Provide handlers for each property inside the object.
  */
+export const makeCodenameObjectHandler =
+  <Entity extends { codename?: string; name?: string }>(
+    innerHandlers: Omit<
+      {
+        readonly [k in keyof Entity]-?:
+          | Handler<Entity[k]>
+          | ContextfulHandler<
+              Readonly<{ source: Entity; target: Entity }>,
+              Entity[k]
+            >;
+      },
+      "id" | "codename" | "external_id"
+    >,
+  ): Handler<Entity> =>
+  (sourceValue, targetValue) => {
+    const customOps: PatchOperation[] = [];
+
+    if (
+      sourceValue.codename !== targetValue.codename &&
+      sourceValue.name === targetValue.name
+    ) {
+      customOps.push({
+        op: "replace",
+        oldValue: targetValue.codename,
+        value: sourceValue.codename,
+        path: "/codename",
+      });
+    }
+
+    return (
+      Object.entries(innerHandlers) as unknown as [
+        keyof Entity & string,
+        (
+          | Handler<Entity[keyof Entity]>
+          | ContextfulHandler<
+              Readonly<{ source: Entity; target: Entity }>,
+              Entity[keyof Entity]
+            >
+        ),
+      ][]
+    )
+      .flatMap(([key, someHandler]) => {
+        const handler =
+          typeof someHandler === "function"
+            ? someHandler
+            : someHandler.contextfulHandler({
+                source: sourceValue,
+                target: targetValue,
+              });
+
+        return handler(sourceValue[key], targetValue[key]).map(
+          prefixOperationPath(key),
+        );
+      })
+      .concat(customOps);
+  };
+
+/**
+ * Create patch operations for changed properties inside the object.
+ *
+ * @param innerHandlers - Provide handlers for each property inside the object.
+ */
 export const makeObjectHandler =
   <Entity extends object>(
     innerHandlers: Omit<
@@ -417,10 +479,10 @@ export const constantHandler: Handler<unknown> = () => [];
  * The main purpose of this is to determine what objects (e.g. types or spaces) need to be added, removed or replaced.
  */
 export const makeWholeObjectsHandler = <
-  Object extends Readonly<{ codename: string; name: string }>,
+  Object extends Readonly<{ codename?: string; name?: string }>,
 >(): Handler<ReadonlyArray<Object>> =>
   makeArrayHandler(
-    (el) => el.codename,
+    (el) => el.codename ?? "",
     makeLeafObjectHandler({ name: () => false } as {
       [k in keyof Object]?: () => false;
     }), // Any property apart from "codename" | "id" | "external_id" works. We just need to make sure that this handler always returns a replace operation, because it is only called on objects with the same codename.

--- a/src/modules/sync/diff/combinators.ts
+++ b/src/modules/sync/diff/combinators.ts
@@ -652,10 +652,10 @@ export const constantHandler: Handler<unknown> = () => [];
  * The main purpose of this is to determine what objects (e.g. types or spaces) need to be added, removed or replaced.
  */
 export const makeWholeObjectsHandler = <
-  Object extends Readonly<{ codename?: string; name?: string }>,
+  Object extends Readonly<{ codename: string; name: string }>,
 >(): Handler<ReadonlyArray<Object>> =>
   makeArrayHandler(
-    (el) => el.codename ?? "",
+    (el) => el.codename,
     makeLeafObjectHandler({ name: () => false } as {
       [k in keyof Object]?: () => false;
     }), // Any property apart from "codename" | "id" | "external_id" works. We just need to make sure that this handler always returns a replace operation, because it is only called on objects with the same codename.

--- a/src/modules/sync/diff/combinators.ts
+++ b/src/modules/sync/diff/combinators.ts
@@ -172,6 +172,28 @@ type LazyHandler<T> = Readonly<{ lazyHandler: () => Handler<T> }>;
  *
  * This adds the "codename:" prefix before the codename in the path property.
  *
+ * @param createUpdateOps - update handler for entities inside the array (will only be called on entities with matching codenames)
+ *
+ * @param transformBeforeAdd - optional transformation of entities before they are added into the "addInto" patch operation
+ */
+export const makeCodenameArrayHandler = <
+  Entity extends { name?: string; codename?: string },
+>(
+  createUpdateOps: Handler<Entity> | LazyHandler<Entity>,
+  transformBeforeAdd: (el: Entity) => Entity = (x) => x,
+): Handler<readonly Entity[]> =>
+  makePrefixHandler(
+    "codename:",
+    (op) => !!op.path,
+    makeCodenameBaseArrayHandler(createUpdateOps, transformBeforeAdd),
+  );
+
+/**
+ * Creates patch operations for entities in an array.
+ * It matches the entities by codename and creates "addInto", "remove" and "replace" operations.
+ *
+ * This adds the "codename:" prefix before the codename in the path property.
+ *
  * @param getCodename - function to get the codename from an entity inside the array
  *
  * @param createUpdateOps - update handler for entities inside the array (will only be called on entities with matching codenames)
@@ -188,6 +210,83 @@ export const makeArrayHandler = <Entity>(
     (op) => !!op.path,
     makeBaseArrayHandler(getCodename, createUpdateOps, transformBeforeAdd),
   );
+
+/**
+ * Creates patch operations for entities in an array.
+ * It matches the entities by codename and creates "addInto", "remove" and "replace" operations.
+ *
+ * This does not add any prefix before the entity codename in path property.
+ *
+ * @param createUpdateOps - update handler for entities inside the array (will only be called on entities with matching codenames)
+ *
+ * @param transformBeforeAdd - optional transformation of entities before they are added into the "addInto" patch operation
+ */
+export const makeCodenameBaseArrayHandler =
+  <Entity extends { name?: string; codename?: string }>(
+    createUpdateOps: Handler<Entity> | LazyHandler<Entity>,
+    transformBeforeAdd: (el: Entity) => Entity = (x) => x,
+  ): Handler<readonly Entity[]> =>
+  (sourceValue, targetValue) => {
+    // needs to be function due to lazy handling
+    const getCreateUpdateOps = () =>
+      typeof createUpdateOps === "object"
+        ? createUpdateOps.lazyHandler()
+        : createUpdateOps;
+
+    const addAndUpdateOps = sourceValue.flatMap((source) => {
+      const targetEntity = targetValue.find(
+        (target) =>
+          target.codename === source.codename || target.name === source.name,
+      );
+
+      if (!targetEntity) {
+        return [
+          {
+            op: "addInto" as const,
+            path: "",
+            value: transformBeforeAdd(source),
+          },
+        ];
+      }
+
+      if (targetEntity.codename !== source.codename) {
+        return [
+          {
+            op: "replace" as const,
+            oldValue: targetEntity.codename,
+            value: source.codename,
+            path: `/${targetEntity.codename}/codename`,
+          },
+          ...getCreateUpdateOps()(source, targetEntity).map(
+            prefixOperationPath(source.codename ?? ""),
+          ),
+        ];
+      }
+
+      return [
+        ...getCreateUpdateOps()(source, targetEntity).map(
+          prefixOperationPath(source.codename ?? ""),
+        ),
+      ];
+    });
+
+    const removeOps = targetValue
+      .filter(
+        (target) =>
+          !sourceValue.find(
+            (source) =>
+              target.codename === source.codename ||
+              target.name === source.name,
+          ),
+      )
+      .map((target) => ({
+        op: "remove" as const,
+        path: "/" + target.codename,
+        oldValue: target,
+      }));
+
+    return [...addAndUpdateOps, ...removeOps];
+  };
 
 /**
  * Creates patch operations for entities in an array.

--- a/src/modules/sync/diff/contentType.ts
+++ b/src/modules/sync/diff/contentType.ts
@@ -9,10 +9,8 @@ import {
   baseHandler,
   Handler,
   makeAdjustOperationHandler,
-  makeArrayHandler,
   makeCodenameArrayHandler,
   makeCodenameObjectHandler,
-  makeObjectHandler,
   makeOrderingHandler,
   makeUnionHandler,
   makeWholeObjectsHandler,
@@ -55,9 +53,8 @@ export const makeContentTypeHandler = (
       name: baseHandler,
       content_groups: optionalHandler(
         makeOrderingHandler(
-          makeArrayHandler(
-            (g) => g.codename ?? "",
-            makeObjectHandler({ name: baseHandler }),
+          makeCodenameArrayHandler(
+            makeCodenameObjectHandler({ name: baseHandler }),
           ),
           (g) => g.codename ?? "",
         ),

--- a/src/modules/sync/diff/contentType.ts
+++ b/src/modules/sync/diff/contentType.ts
@@ -56,7 +56,7 @@ export const makeContentTypeHandler = (
           makeCodenameArrayHandler(
             makeCodenameObjectHandler({ name: baseHandler }),
           ),
-          (g) => g.codename ?? "",
+          (g) => g.codename,
         ),
       ),
       elements: {

--- a/src/modules/sync/diff/contentType.ts
+++ b/src/modules/sync/diff/contentType.ts
@@ -10,6 +10,7 @@ import {
   Handler,
   makeAdjustOperationHandler,
   makeArrayHandler,
+  makeCodenameObjectHandler,
   makeObjectHandler,
   makeOrderingHandler,
   makeUnionHandler,
@@ -34,14 +35,8 @@ import {
 import { transformGuidelinesElementToAddModel } from "./transformToAddModel.js";
 
 type HandleContentTypeParams = Readonly<{
-  targetItemsByCodenames: ReadonlyMap<
-    string,
-    Readonly<{ id: string; codename: string }>
-  >;
-  targetAssetsByCodenames: ReadonlyMap<
-    string,
-    Readonly<{ id: string; codename: string }>
-  >;
+  targetItemsByCodenames: ReadonlyMap<string, Readonly<{ id: string; codename: string }>>;
+  targetAssetsByCodenames: ReadonlyMap<string, Readonly<{ id: string; codename: string }>>;
 }>;
 
 export const makeContentTypeHandler = (
@@ -49,24 +44,19 @@ export const makeContentTypeHandler = (
 ): Handler<ContentTypeSyncModel> =>
   makeAdjustOperationHandler(
     (arr) => arr.toSorted(contentTypeOperationsComparator),
-    makeObjectHandler({
+    makeCodenameObjectHandler({
       name: baseHandler,
       content_groups: optionalHandler(
         makeOrderingHandler(
-          makeArrayHandler(
-            (g) => g.codename,
-            makeObjectHandler({ name: baseHandler }),
-          ),
-          (g) => g.codename,
+          makeArrayHandler(g => g.codename ?? "", makeObjectHandler({ name: baseHandler })),
+          g => g.codename ?? "",
         ),
       ),
       elements: {
         contextfulHandler: ({ source, target }) => {
           const ctx = {
             ...params,
-            targetAssetCodenames: new Set(
-              params.targetAssetsByCodenames.keys(),
-            ),
+            targetAssetCodenames: new Set(params.targetAssetsByCodenames.keys()),
             targetItemCodenames: new Set(params.targetItemsByCodenames.keys()),
             sourceTypeOrSnippet: source,
             targetTypeOrSnippet: target,
@@ -74,7 +64,7 @@ export const makeContentTypeHandler = (
 
           return makeOrderingHandler(
             makeArrayHandler(
-              (el) => el.codename,
+              el => el.codename,
               makeUnionHandler("type", {
                 number: makeNumberElementHandler(ctx),
                 text: makeTextElementHandler(ctx),
@@ -90,22 +80,17 @@ export const makeContentTypeHandler = (
                 modular_content: makeLinkedItemsElementHandler(ctx),
                 multiple_choice: makeMultiChoiceElementHandler(ctx),
               }),
-              (el) =>
+              el =>
                 el.type === "guidelines"
-                  ? (transformGuidelinesElementToAddModel(
-                      {
-                        targetItemsReferencedFromSourceByCodenames:
-                          params.targetItemsByCodenames,
-                        targetAssetsReferencedFromSourceByCodenames:
-                          params.targetAssetsByCodenames,
-                      },
-                      el,
-                    ) as SyncGuidelinesElement)
+                  ? transformGuidelinesElementToAddModel({
+                    targetItemsReferencedFromSourceByCodenames: params.targetItemsByCodenames,
+                    targetAssetsReferencedFromSourceByCodenames: params.targetAssetsByCodenames,
+                  }, el) as SyncGuidelinesElement
                   : el,
             ),
-            (e) => e.codename,
+            e => e.codename,
             {
-              groupBy: (e) => e.content_group?.codename ?? "",
+              groupBy: e => e.content_group?.codename ?? "",
               // at the moment, snippet can't be referenced due to the bug.
               filter: (el) => el.type !== "snippet",
             },
@@ -150,11 +135,7 @@ const patchOpToOrdNumber = (op: PatchOperation) => {
   }
 };
 
-const contentTypeOperationsComparator = (
-  el1: PatchOperation,
-  el2: PatchOperation,
-): number => patchOpToOrdNumber(el1) - patchOpToOrdNumber(el2);
+const contentTypeOperationsComparator = (el1: PatchOperation, el2: PatchOperation): number =>
+  patchOpToOrdNumber(el1) - patchOpToOrdNumber(el2);
 
-export const wholeContentTypesHandler: Handler<
-  ReadonlyArray<ContentTypeSyncModel>
-> = makeWholeObjectsHandler();
+export const wholeContentTypesHandler: Handler<ReadonlyArray<ContentTypeSyncModel>> = makeWholeObjectsHandler();

--- a/src/modules/sync/diff/contentType.ts
+++ b/src/modules/sync/diff/contentType.ts
@@ -10,6 +10,7 @@ import {
   Handler,
   makeAdjustOperationHandler,
   makeArrayHandler,
+  makeCodenameArrayHandler,
   makeCodenameObjectHandler,
   makeObjectHandler,
   makeOrderingHandler,
@@ -35,8 +36,14 @@ import {
 import { transformGuidelinesElementToAddModel } from "./transformToAddModel.js";
 
 type HandleContentTypeParams = Readonly<{
-  targetItemsByCodenames: ReadonlyMap<string, Readonly<{ id: string; codename: string }>>;
-  targetAssetsByCodenames: ReadonlyMap<string, Readonly<{ id: string; codename: string }>>;
+  targetItemsByCodenames: ReadonlyMap<
+    string,
+    Readonly<{ id: string; codename: string }>
+  >;
+  targetAssetsByCodenames: ReadonlyMap<
+    string,
+    Readonly<{ id: string; codename: string }>
+  >;
 }>;
 
 export const makeContentTypeHandler = (
@@ -48,23 +55,27 @@ export const makeContentTypeHandler = (
       name: baseHandler,
       content_groups: optionalHandler(
         makeOrderingHandler(
-          makeArrayHandler(g => g.codename ?? "", makeObjectHandler({ name: baseHandler })),
-          g => g.codename ?? "",
+          makeArrayHandler(
+            (g) => g.codename ?? "",
+            makeObjectHandler({ name: baseHandler }),
+          ),
+          (g) => g.codename ?? "",
         ),
       ),
       elements: {
         contextfulHandler: ({ source, target }) => {
           const ctx = {
             ...params,
-            targetAssetCodenames: new Set(params.targetAssetsByCodenames.keys()),
+            targetAssetCodenames: new Set(
+              params.targetAssetsByCodenames.keys(),
+            ),
             targetItemCodenames: new Set(params.targetItemsByCodenames.keys()),
             sourceTypeOrSnippet: source,
             targetTypeOrSnippet: target,
           };
 
           return makeOrderingHandler(
-            makeArrayHandler(
-              el => el.codename,
+            makeCodenameArrayHandler(
               makeUnionHandler("type", {
                 number: makeNumberElementHandler(ctx),
                 text: makeTextElementHandler(ctx),
@@ -80,17 +91,22 @@ export const makeContentTypeHandler = (
                 modular_content: makeLinkedItemsElementHandler(ctx),
                 multiple_choice: makeMultiChoiceElementHandler(ctx),
               }),
-              el =>
+              (el) =>
                 el.type === "guidelines"
-                  ? transformGuidelinesElementToAddModel({
-                    targetItemsReferencedFromSourceByCodenames: params.targetItemsByCodenames,
-                    targetAssetsReferencedFromSourceByCodenames: params.targetAssetsByCodenames,
-                  }, el) as SyncGuidelinesElement
+                  ? (transformGuidelinesElementToAddModel(
+                      {
+                        targetItemsReferencedFromSourceByCodenames:
+                          params.targetItemsByCodenames,
+                        targetAssetsReferencedFromSourceByCodenames:
+                          params.targetAssetsByCodenames,
+                      },
+                      el,
+                    ) as SyncGuidelinesElement)
                   : el,
             ),
-            e => e.codename,
+            (e) => e.codename,
             {
-              groupBy: e => e.content_group?.codename ?? "",
+              groupBy: (e) => e.content_group?.codename ?? "",
               // at the moment, snippet can't be referenced due to the bug.
               filter: (el) => el.type !== "snippet",
             },
@@ -135,7 +151,11 @@ const patchOpToOrdNumber = (op: PatchOperation) => {
   }
 };
 
-const contentTypeOperationsComparator = (el1: PatchOperation, el2: PatchOperation): number =>
-  patchOpToOrdNumber(el1) - patchOpToOrdNumber(el2);
+const contentTypeOperationsComparator = (
+  el1: PatchOperation,
+  el2: PatchOperation,
+): number => patchOpToOrdNumber(el1) - patchOpToOrdNumber(el2);
 
-export const wholeContentTypesHandler: Handler<ReadonlyArray<ContentTypeSyncModel>> = makeWholeObjectsHandler();
+export const wholeContentTypesHandler: Handler<
+  ReadonlyArray<ContentTypeSyncModel>
+> = makeWholeObjectsHandler();

--- a/src/modules/sync/diff/contentTypeSnippet.ts
+++ b/src/modules/sync/diff/contentTypeSnippet.ts
@@ -8,8 +8,8 @@ import {
   baseHandler,
   Handler,
   makeAdjustOperationHandler,
-  makeArrayHandler,
-  makeObjectHandler,
+  makeCodenameArrayHandler,
+  makeCodenameObjectHandler,
   makeOrderingHandler,
   makeUnionHandler,
   makeWholeObjectsHandler,
@@ -41,7 +41,7 @@ type HandleContentTypeSnippetParams = Readonly<{
 export const makeContentTypeSnippetHandler = (
   params: HandleContentTypeSnippetParams,
 ): Handler<ContentTypeSnippetsSyncModel> =>
-  makeObjectHandler({
+  makeCodenameObjectHandler({
     name: baseHandler,
     elements: {
       contextfulHandler: ({ source, target }) => {
@@ -56,8 +56,7 @@ export const makeContentTypeSnippetHandler = (
         return makeAdjustOperationHandler(
           (ops) => ops.toSorted(snippetOperationsComparator),
           makeOrderingHandler(
-            makeArrayHandler(
-              (el) => el.codename,
+            makeCodenameArrayHandler(
               makeUnionHandler("type", {
                 number: makeNumberElementHandler(ctx),
                 text: makeTextElementHandler(ctx),

--- a/src/modules/sync/diff/taxonomy.ts
+++ b/src/modules/sync/diff/taxonomy.ts
@@ -10,10 +10,9 @@ import {
   Handler,
   makeAdjustEntityHandler,
   makeAdjustOperationHandler,
-  makeArrayHandler,
+  makeCodenameArrayHandler,
   makeCodenameObjectHandler,
-  makeObjectHandler,
-  makeOrderingHandler,
+  makeCodenameOrderingHandler,
   makeProvideHandler,
   makeWholeObjectsHandler,
 } from "./combinators.js";
@@ -45,12 +44,11 @@ type FlattenedSyncTaxonomy = Replace<TaxonomySyncModel, { terms: [] }> &
 export const makeFlattenedTaxonomyHandler = (
   topLevelTargetTermCodenames: ReadonlyArray<string>,
 ): Handler<ReadonlyArray<FlattenedSyncTaxonomy>> =>
-  makeOrderingHandler(
-    makeArrayHandler(
-      (t) => t.codename,
+  makeCodenameOrderingHandler(
+    makeCodenameArrayHandler(
       makeAdjustOperationHandler(
         (ops) => ops.map(stripPositionFromPath),
-        makeObjectHandler({
+        makeCodenameObjectHandler({
           name: baseHandler,
           terms: constantHandler,
           position: (sourcePos, targetPos) => {
@@ -90,7 +88,6 @@ export const makeFlattenedTaxonomyHandler = (
         }),
       ),
     ),
-    (t) => t.codename,
     { groupBy: (t) => t.position.join("/") },
   );
 

--- a/src/modules/sync/diff/taxonomy.ts
+++ b/src/modules/sync/diff/taxonomy.ts
@@ -11,6 +11,7 @@ import {
   makeAdjustEntityHandler,
   makeAdjustOperationHandler,
   makeArrayHandler,
+  makeCodenameObjectHandler,
   makeObjectHandler,
   makeOrderingHandler,
   makeProvideHandler,
@@ -18,7 +19,7 @@ import {
 } from "./combinators.js";
 
 export const taxonomyGroupHandler: Handler<TaxonomySyncModel> =
-  makeObjectHandler({
+  makeCodenameObjectHandler({
     name: baseHandler,
     terms: {
       contextfulHandler: ({ target }) =>

--- a/tests/unit/syncModel/diff/contentType.test.ts
+++ b/tests/unit/syncModel/diff/contentType.test.ts
@@ -166,8 +166,7 @@ describe("makeContentTypeHandler", () => {
         {
           type: "guidelines",
           codename: "guidelines",
-          guidelines:
-            `<p><a data-item-codename="item" data-item-external-id="itemE">item link</a>xyz <a data-asset-codename="asset1" data-asset-external-id="asset1E">asset link</a></p><figure data-asset-codename="asset2" data-asset-external-id="asset2E"><img src="#" data-asset-codename="asset2" data-asset-external-id="asset2E"/></figure><p><a data-asset-external-id="assetN">non-existing asset link</a></p>`,
+          guidelines: `<p><a data-item-codename="item" data-item-external-id="itemE">item link</a>xyz <a data-asset-codename="asset1" data-asset-external-id="asset1E">asset link</a></p><figure data-asset-codename="asset2" data-asset-external-id="asset2E"><img src="#" data-asset-codename="asset2" data-asset-external-id="asset2E"/></figure><p><a data-asset-external-id="assetN">non-existing asset link</a></p>`,
         },
       ],
     };
@@ -178,21 +177,26 @@ describe("makeContentTypeHandler", () => {
     };
 
     const result = makeContentTypeHandler({
-      targetItemsByCodenames: new Map([["item", { id: "itemId", codename: "item" }]]),
+      targetItemsByCodenames: new Map([
+        ["item", { id: "itemId", codename: "item" }],
+      ]),
       targetAssetsByCodenames: new Map([
         ["asset1", { id: "asset1Id", codename: "asset1" }],
         ["asset2", { id: "asset2Id", codename: "asset2" }],
       ]),
     })(source, target);
 
-    const resultWithFilteredSpaces = result
-      .map(op => ({
-        ...op,
-        value: op.op === "addInto" && typeof op.value === "object" && op.value !== null && "guidelines" in op.value
-          && typeof op.value.guidelines === "string"
+    const resultWithFilteredSpaces = result.map((op) => ({
+      ...op,
+      value:
+        op.op === "addInto" &&
+        typeof op.value === "object" &&
+        op.value !== null &&
+        "guidelines" in op.value &&
+        typeof op.value.guidelines === "string"
           ? { ...op.value, guidelines: removeSpaces(op.value.guidelines) }
           : {},
-      }));
+    }));
 
     expect(resultWithFilteredSpaces).toStrictEqual([
       {
@@ -209,79 +213,128 @@ describe("makeContentTypeHandler", () => {
     ]);
   });
 
-  it("creates replace operations for codename changes for a content type, but with the same name", () => {
-    const source: ContentTypeSyncModel = {
-      name: "test type",
-      codename: "new_type",
-      elements: [],
-    };
-    const target: ContentTypeSyncModel = {
-      name: "test type",
-      codename: "old_type",
-      elements: [],
-    };
+  describe("match by name instead of codename", () => {
+    it("creates replace operations for codename changes for a content type, but with the same name", () => {
+      const source: ContentTypeSyncModel = {
+        name: "test type",
+        codename: "new_type",
+        elements: [],
+      };
+      const target: ContentTypeSyncModel = {
+        name: "test type",
+        codename: "old_type",
+        elements: [],
+      };
 
-    const result = makeContentTypeHandler({
-      targetItemsByCodenames: new Map(),
-      targetAssetsByCodenames: new Map(),
-    })(source, target);
+      const result = makeContentTypeHandler({
+        targetItemsByCodenames: new Map(),
+        targetAssetsByCodenames: new Map(),
+      })(source, target);
 
-    expect(result).toStrictEqual([
-      {
-        op: "replace",
-        path: "/codename",
-        value: "new_type",
-        oldValue: "old_type",
-      }
-    ]);
-  });
-
-  it("creates replace operations for elements with codename changes, but with the same name", () => {
-    const source: ContentTypeSyncModel = {
-      name: "test type",
-      codename: "type",
-      elements: [
+      expect(result).toStrictEqual([
         {
-          type: "number",
-          codename: "element_1",
-          name: "number",
+          op: "replace",
+          path: "/codename",
+          value: "new_type",
+          oldValue: "old_type",
         },
-        {
-          type: "text",
-          codename: "element_2_new",
-          name: "text",
-        },
-      ],
-    };
-    const target: ContentTypeSyncModel = {
-      name: "test type",
-      codename: "type",
-      elements: [
-        {
-          type: "number",
-          codename: "element_1",
-          name: "number",
-        },
-        {
-          type: "text",
-          codename: "element_2",
-          name: "text",
-        },
-      ],
-    };
+      ]);
+    });
 
-    const result = makeContentTypeHandler({
-      targetItemsByCodenames: new Map(),
-      targetAssetsByCodenames: new Map(),
-    })(source, target);
+    it("creates replace operations for elements with codename changes, but with the same name", () => {
+      const source: ContentTypeSyncModel = {
+        name: "test type",
+        codename: "type",
+        elements: [
+          {
+            type: "number",
+            codename: "element_1",
+            name: "number",
+          },
+          {
+            type: "text",
+            codename: "element_2_new",
+            name: "text",
+          },
+        ],
+      };
+      const target: ContentTypeSyncModel = {
+        name: "test type",
+        codename: "type",
+        elements: [
+          {
+            type: "number",
+            codename: "element_1",
+            name: "number",
+          },
+          {
+            type: "text",
+            codename: "element_2",
+            name: "text",
+          },
+        ],
+      };
 
-    expect(result).toStrictEqual([
-      {
-        op: "replace",
-        path: "/elements/codename:element_2/codename",
-        value: "element_2_new",
-        oldValue: "element_2"
-      }
-    ]);
+      const result = makeContentTypeHandler({
+        targetItemsByCodenames: new Map(),
+        targetAssetsByCodenames: new Map(),
+      })(source, target);
+
+      expect(result).toStrictEqual([
+        {
+          op: "replace",
+          path: "/elements/codename:element_2/codename",
+          value: "element_2_new",
+          oldValue: "element_2",
+        },
+      ]);
+    });
+
+    it("creates replace operations for content gruops with different codenames, but with the same name", () => {
+      const source: ContentTypeSyncModel = {
+        name: "some content type",
+        codename: "type",
+        content_groups: [
+          {
+            name: "group 1",
+            codename: "group1",
+          },
+          {
+            name: "group 2",
+            codename: "group2_new_codename",
+          },
+        ],
+        elements: [],
+      };
+      const target: ContentTypeSyncModel = {
+        name: "some content type",
+        codename: "type",
+        content_groups: [
+          {
+            name: "group 1",
+            codename: "group1",
+          },
+          {
+            name: "group 2",
+            codename: "group2",
+          },
+        ],
+        elements: [],
+      };
+
+      const result = makeContentTypeHandler({
+        targetItemsByCodenames: new Map(),
+        targetAssetsByCodenames: new Map(),
+      })(source, target);
+
+      expect(result).toStrictEqual([
+        {
+          op: "replace",
+          path: "/content_groups/codename:group2/codename",
+          value: "group2_new_codename",
+          oldValue: "group2",
+        },
+      ]);
+    });
   });
 });

--- a/tests/unit/syncModel/diff/contentType.test.ts
+++ b/tests/unit/syncModel/diff/contentType.test.ts
@@ -235,4 +235,53 @@ describe("makeContentTypeHandler", () => {
       }
     ]);
   });
+
+  it("creates replace operations for elements with codename changes, but with the same name", () => {
+    const source: ContentTypeSyncModel = {
+      name: "test type",
+      codename: "type",
+      elements: [
+        {
+          type: "number",
+          codename: "element_1",
+          name: "number",
+        },
+        {
+          type: "text",
+          codename: "element_2_new",
+          name: "text",
+        },
+      ],
+    };
+    const target: ContentTypeSyncModel = {
+      name: "test type",
+      codename: "type",
+      elements: [
+        {
+          type: "number",
+          codename: "element_1",
+          name: "number",
+        },
+        {
+          type: "text",
+          codename: "element_2",
+          name: "text",
+        },
+      ],
+    };
+
+    const result = makeContentTypeHandler({
+      targetItemsByCodenames: new Map(),
+      targetAssetsByCodenames: new Map(),
+    })(source, target);
+
+    expect(result).toStrictEqual([
+      {
+        op: "replace",
+        path: "/elements/codename:element_2/codename",
+        value: "element_2_new",
+        oldValue: "element_2"
+      }
+    ]);
+  });
 });

--- a/tests/unit/syncModel/diff/contentType.test.ts
+++ b/tests/unit/syncModel/diff/contentType.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { makeContentTypeHandler } from "../../../../src/modules/sync/diff/contentType.ts";
-import { ContentTypeSyncModel } from "../../../../src/modules/sync/types/syncModel.ts";
+import {
+  ContentTypeSyncModel,
+  SyncTypeSnippetElement,
+} from "../../../../src/modules/sync/types/syncModel.ts";
 import { removeSpaces } from "./utils.ts";
 
 describe("makeContentTypeHandler", () => {
@@ -333,6 +336,63 @@ describe("makeContentTypeHandler", () => {
           path: "/content_groups/codename:group2/codename",
           value: "group2_new_codename",
           oldValue: "group2",
+        },
+      ]);
+    });
+
+    it("deletes existing snippet and adds the new one when codenames don't match", () => {
+      const source: ContentTypeSyncModel = {
+        name: "test type",
+        codename: "type",
+        elements: [
+          {
+            type: "snippet",
+            codename: "element_1_new",
+          } as SyncTypeSnippetElement,
+          {
+            type: "text",
+            codename: "element_2",
+            name: "text",
+          },
+        ],
+      };
+      const target: ContentTypeSyncModel = {
+        name: "test type",
+        codename: "type",
+        elements: [
+          {
+            type: "snippet",
+            codename: "element_1",
+          } as SyncTypeSnippetElement,
+          {
+            type: "text",
+            codename: "element_2",
+            name: "text",
+          },
+        ],
+      };
+
+      const result = makeContentTypeHandler({
+        targetItemsByCodenames: new Map(),
+        targetAssetsByCodenames: new Map(),
+      })(source, target);
+
+      expect(result).toStrictEqual([
+        {
+          op: "addInto",
+          path: "/elements",
+          value: {
+            type: "snippet",
+            codename: "element_1_new",
+          },
+        },
+        {
+          op: "remove",
+          path: "/elements/codename:element_1",
+          oldValue: {
+            type: "snippet",
+            codename: "element_1",
+          },
         },
       ]);
     });

--- a/tests/unit/syncModel/diff/contentType.test.ts
+++ b/tests/unit/syncModel/diff/contentType.test.ts
@@ -166,7 +166,8 @@ describe("makeContentTypeHandler", () => {
         {
           type: "guidelines",
           codename: "guidelines",
-          guidelines: `<p><a data-item-codename="item" data-item-external-id="itemE">item link</a>xyz <a data-asset-codename="asset1" data-asset-external-id="asset1E">asset link</a></p><figure data-asset-codename="asset2" data-asset-external-id="asset2E"><img src="#" data-asset-codename="asset2" data-asset-external-id="asset2E"/></figure><p><a data-asset-external-id="assetN">non-existing asset link</a></p>`,
+          guidelines:
+            `<p><a data-item-codename="item" data-item-external-id="itemE">item link</a>xyz <a data-asset-codename="asset1" data-asset-external-id="asset1E">asset link</a></p><figure data-asset-codename="asset2" data-asset-external-id="asset2E"><img src="#" data-asset-codename="asset2" data-asset-external-id="asset2E"/></figure><p><a data-asset-external-id="assetN">non-existing asset link</a></p>`,
         },
       ],
     };
@@ -177,26 +178,21 @@ describe("makeContentTypeHandler", () => {
     };
 
     const result = makeContentTypeHandler({
-      targetItemsByCodenames: new Map([
-        ["item", { id: "itemId", codename: "item" }],
-      ]),
+      targetItemsByCodenames: new Map([["item", { id: "itemId", codename: "item" }]]),
       targetAssetsByCodenames: new Map([
         ["asset1", { id: "asset1Id", codename: "asset1" }],
         ["asset2", { id: "asset2Id", codename: "asset2" }],
       ]),
     })(source, target);
 
-    const resultWithFilteredSpaces = result.map((op) => ({
-      ...op,
-      value:
-        op.op === "addInto" &&
-        typeof op.value === "object" &&
-        op.value !== null &&
-        "guidelines" in op.value &&
-        typeof op.value.guidelines === "string"
+    const resultWithFilteredSpaces = result
+      .map(op => ({
+        ...op,
+        value: op.op === "addInto" && typeof op.value === "object" && op.value !== null && "guidelines" in op.value
+          && typeof op.value.guidelines === "string"
           ? { ...op.value, guidelines: removeSpaces(op.value.guidelines) }
           : {},
-    }));
+      }));
 
     expect(resultWithFilteredSpaces).toStrictEqual([
       {
@@ -210,6 +206,33 @@ describe("makeContentTypeHandler", () => {
           ),
         },
       },
+    ]);
+  });
+
+  it("creates replace operations for codename changes for a content type, but with the same name", () => {
+    const source: ContentTypeSyncModel = {
+      name: "test type",
+      codename: "new_type",
+      elements: [],
+    };
+    const target: ContentTypeSyncModel = {
+      name: "test type",
+      codename: "old_type",
+      elements: [],
+    };
+
+    const result = makeContentTypeHandler({
+      targetItemsByCodenames: new Map(),
+      targetAssetsByCodenames: new Map(),
+    })(source, target);
+
+    expect(result).toStrictEqual([
+      {
+        op: "replace",
+        path: "/codename",
+        value: "new_type",
+        oldValue: "old_type",
+      }
     ]);
   });
 });

--- a/tests/unit/syncModel/diff/contentTypeSnippet.test.ts
+++ b/tests/unit/syncModel/diff/contentTypeSnippet.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { makeContentTypeSnippetHandler } from "../../../../src/modules/sync/diff/contentTypeSnippet";
+import { ContentTypeSnippetsSyncModel } from "../../../../src/modules/sync/types/syncModel";
+
+describe("makeContentTypeSnippetHandler", () => {
+  it("creates operations for all changed properties", () => {
+    const source: ContentTypeSnippetsSyncModel = {
+      name: "new name",
+      codename: "type",
+      elements: [
+        {
+          type: "number",
+          codename: "element_1",
+          name: "number",
+        },
+        {
+          type: "text",
+          codename: "element_2",
+          name: "text",
+        },
+        {
+          type: "date_time",
+          codename: "element_3",
+          name: "date",
+        },
+      ],
+    };
+    const target: ContentTypeSnippetsSyncModel = {
+      name: "old name",
+      codename: "type",
+      elements: [
+        {
+          type: "number",
+          codename: "element_1",
+          name: "num",
+        },
+        {
+          type: "date_time",
+          codename: "element_3",
+          name: "date",
+        },
+        {
+          type: "text",
+          codename: "toDelete",
+          name: "to delete",
+        },
+        {
+          type: "text",
+          codename: "element_2",
+          name: "txt",
+        },
+      ],
+    };
+
+    const result = makeContentTypeSnippetHandler({
+      targetItemsByCodenames: new Map(),
+      targetAssetsByCodenames: new Map(),
+    })(source, target);
+
+    expect(result).toStrictEqual([
+      {
+        op: "replace",
+        path: "/name",
+        value: "new name",
+        oldValue: "old name",
+      },
+      {
+        op: "replace",
+        path: "/elements/codename:element_1/name",
+        value: "number",
+        oldValue: "num",
+      },
+      {
+        op: "replace",
+        path: "/elements/codename:element_2/name",
+        value: "text",
+        oldValue: "txt",
+      },
+      {
+        op: "remove",
+        path: "/elements/codename:toDelete",
+        oldValue: {
+          type: "text",
+          codename: "toDelete",
+          name: "to delete",
+        },
+      },
+      {
+        op: "move",
+        path: "/elements/codename:element_2",
+        after: {
+          codename: "element_1",
+        },
+      },
+      {
+        op: "move",
+        path: "/elements/codename:element_3",
+        after: {
+          codename: "element_2",
+        },
+      },
+    ]);
+  });
+});

--- a/tests/unit/syncModel/diff/contentTypeSnippet.test.ts
+++ b/tests/unit/syncModel/diff/contentTypeSnippet.test.ts
@@ -102,4 +102,82 @@ describe("makeContentTypeSnippetHandler", () => {
       },
     ]);
   });
+
+  describe("match by name instead of codename", () => {
+    it("creates replace operations for codename changes for a content type snippet, but with the same name", () => {
+      const source: ContentTypeSnippetsSyncModel = {
+        name: "test type",
+        codename: "new_type",
+        elements: [],
+      };
+      const target: ContentTypeSnippetsSyncModel = {
+        name: "test type",
+        codename: "old_type",
+        elements: [],
+      };
+
+      const result = makeContentTypeSnippetHandler({
+        targetItemsByCodenames: new Map(),
+        targetAssetsByCodenames: new Map(),
+      })(source, target);
+
+      expect(result).toStrictEqual([
+        {
+          op: "replace",
+          path: "/codename",
+          value: "new_type",
+          oldValue: "old_type",
+        },
+      ]);
+    });
+
+    it("creates replace operations for elements with codename changes, but with the same name", () => {
+      const source: ContentTypeSnippetsSyncModel = {
+        name: "test type",
+        codename: "type",
+        elements: [
+          {
+            type: "number",
+            codename: "element_1",
+            name: "number",
+          },
+          {
+            type: "text",
+            codename: "element_2_new",
+            name: "text",
+          },
+        ],
+      };
+      const target: ContentTypeSnippetsSyncModel = {
+        name: "test type",
+        codename: "type",
+        elements: [
+          {
+            type: "number",
+            codename: "element_1",
+            name: "number",
+          },
+          {
+            type: "text",
+            codename: "element_2",
+            name: "text",
+          },
+        ],
+      };
+
+      const result = makeContentTypeSnippetHandler({
+        targetItemsByCodenames: new Map(),
+        targetAssetsByCodenames: new Map(),
+      })(source, target);
+
+      expect(result).toStrictEqual([
+        {
+          op: "replace",
+          path: "/elements/codename:element_2/codename",
+          value: "element_2_new",
+          oldValue: "element_2",
+        },
+      ]);
+    });
+  });
 });

--- a/tests/unit/syncModel/diff/taxonomyGroup.test.ts
+++ b/tests/unit/syncModel/diff/taxonomyGroup.test.ts
@@ -253,7 +253,7 @@ describe("makeTaxonomyGroupHandler", () => {
   });
 
   describe("match by name instead of codename", () => {
-    it("correctly create patch operations for taxonomy when codename is different, but with the same name", () => {
+    it("correctly creates patch operations for taxonomy when codename is different, but with the same name", () => {
       const source: TaxonomySyncModel = {
         name: "Taxonomy Group",
         codename: "taxonomy_group_new",
@@ -276,5 +276,53 @@ describe("makeTaxonomyGroupHandler", () => {
         },
       ]);
     });
+  });
+
+  it("correctly creates patch operations for taxonomy groups with nested terms when their codenames are different, but with the same names", () => {
+    const source: TaxonomySyncModel = {
+      name: "New group name",
+      codename: "taxonomy_group",
+      terms: [
+        {
+          name: "Term One",
+          codename: "term1_new",
+          terms: [],
+        },
+        {
+          ...makeTerm("term2"),
+        },
+      ],
+    };
+    const target: TaxonomySyncModel = {
+      name: "Old group name",
+      codename: "taxonomy_group",
+      terms: [
+        {
+          name: "Term One",
+          codename: "term1",
+          terms: [],
+        },
+        {
+          ...makeTerm("term2"),
+        },
+      ],
+    };
+
+    const result = taxonomyGroupHandler(source, target);
+
+    expect(result).toStrictEqual([
+      {
+        op: "replace",
+        path: "/name",
+        value: "New group name",
+        oldValue: "Old group name",
+      },
+      {
+        op: "replace",
+        path: "/terms/codename:term1/codename",
+        value: "term1_new",
+        oldValue: "term1",
+      },
+    ]);
   });
 });

--- a/tests/unit/syncModel/diff/taxonomyGroup.test.ts
+++ b/tests/unit/syncModel/diff/taxonomyGroup.test.ts
@@ -251,4 +251,30 @@ describe("makeTaxonomyGroupHandler", () => {
       },
     ]);
   });
+
+  describe("match by name instead of codename", () => {
+    it("correctly create patch operations for taxonomy when codename is different, but with the same name", () => {
+      const source: TaxonomySyncModel = {
+        name: "Taxonomy Group",
+        codename: "taxonomy_group_new",
+        terms: [],
+      };
+      const target: TaxonomySyncModel = {
+        name: "Taxonomy Group",
+        codename: "taxonomy_group",
+        terms: [],
+      };
+
+      const result = taxonomyGroupHandler(source, target);
+
+      expect(result).toStrictEqual([
+        {
+          op: "replace",
+          path: "/codename",
+          value: "taxonomy_group_new",
+          oldValue: "taxonomy_group",
+        },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Made new handler methods for the following migration item types:
- Content Type
- Content Type Snippet
- Taxonomy

These new handler methods now support matching items based on either codename, or name. New methods were created rather than editing existing ones to limit the surface area of these updates, so we could be a bit more surgical in its implementation.